### PR TITLE
Add Order controller and OData registration

### DIFF
--- a/NapoleonCRM.Shared/Models/Order.cs
+++ b/NapoleonCRM.Shared/Models/Order.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Runtime.Serialization;
+
+namespace NapoleonCRM.Shared.Models;
+
+[DataContract]
+public class Order
+{
+    [Key]
+    [DataMember]
+    public long? Id { get; set; }
+
+    [DataMember]
+    public long? CustomerId { get; set; }
+
+    [DataMember]
+    public Customer? Customer { get; set; }
+
+    [DataMember]
+    public List<OrderDetail>? OrderDetails { get; set; }
+
+    [DataMember]
+    public DateTime? OrderDate { get; set; }
+
+    [DataMember]
+    public decimal? TotalAmount { get; set; }
+
+    [DataMember]
+    public DateTime? CreatedDate { get; set; }
+
+    [DataMember]
+    public DateTime ModifiedDate { get; set; }
+}

--- a/NapoleonCRM.Shared/Models/OrderDetail.cs
+++ b/NapoleonCRM.Shared/Models/OrderDetail.cs
@@ -1,0 +1,34 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Runtime.Serialization;
+
+namespace NapoleonCRM.Shared.Models;
+
+[DataContract]
+public class OrderDetail
+{
+    [Key]
+    [DataMember]
+    public long? Id { get; set; }
+
+    [DataMember]
+    public long? OrderId { get; set; }
+
+    [DataMember]
+    public Order? Order { get; set; }
+
+    [DataMember]
+    public long? ProductId { get; set; }
+
+    [DataMember]
+    public Product? Product { get; set; }
+
+    [DataMember]
+    public long? Quantity { get; set; }
+
+    [DataMember]
+    public decimal? UnitPrice { get; set; }
+
+    [DataMember]
+    public decimal? TotalPrice { get; set; }
+}

--- a/NapoleonCRM/Controllers/OrderController.cs
+++ b/NapoleonCRM/Controllers/OrderController.cs
@@ -1,0 +1,149 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.OData.Deltas;
+using Microsoft.AspNetCore.OData.Query;
+using Microsoft.AspNetCore.OData.Routing.Attributes;
+using Microsoft.AspNetCore.RateLimiting;
+using Microsoft.EntityFrameworkCore;
+using NapoleonCRM.Data;
+using NapoleonCRM.Shared.Models;
+
+namespace NapoleonCRM.Controllers;
+
+[Route("api/[controller]")]
+[ApiController]
+[Authorize]
+[EnableRateLimiting("Fixed")]
+public class OrderController(ApplicationDbContext _ctx, ILogger<OrderController> _logger) : ControllerBase
+{
+    private readonly ILogger<OrderController> logger = _logger;
+    private readonly ApplicationDbContext ctx = _ctx;
+
+    [HttpGet("")]
+    [EnableQuery]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public ActionResult<IQueryable<Order>> Get()
+    {
+        return Ok(ctx.Order.Include(x => x.Customer).Include(x => x.OrderDetails).ThenInclude(x => x.Product));
+    }
+
+    [HttpGet("{key}")]
+    [EnableQuery]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<Order>> GetAsync(long key)
+    {
+        var order = await ctx.Order.Include(x => x.Customer).Include(x => x.OrderDetails).ThenInclude(x => x.Product).FirstOrDefaultAsync(x => x.Id == key);
+
+        if (order == null)
+        {
+            return NotFound();
+        }
+        else
+        {
+            return Ok(order);
+        }
+    }
+
+    [HttpPost("")]
+    [ProducesResponseType(StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<ActionResult<Order>> PostAsync(Order order)
+    {
+        var record = await ctx.Order.FindAsync(order.Id);
+        if (record != null)
+        {
+            return Conflict();
+        }
+
+        var details = order.OrderDetails;
+        order.OrderDetails = null;
+
+        await ctx.Order.AddAsync(order);
+
+        if (details != null)
+        {
+            foreach (var detail in details)
+            {
+                detail.Product = detail.ProductId.HasValue ? await ctx.Product.FindAsync(detail.ProductId.Value) : null;
+                order.OrderDetails ??= [];
+                order.OrderDetails.Add(detail);
+            }
+        }
+
+        await ctx.SaveChangesAsync();
+
+        return Created($"/order/{order.Id}", order);
+    }
+
+    [HttpPut("{key}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<Order>> PutAsync(long key, Order update)
+    {
+        var order = await ctx.Order.Include(x => x.OrderDetails).FirstOrDefaultAsync(x => x.Id == key);
+
+        if (order == null)
+        {
+            return NotFound();
+        }
+
+        ctx.Entry(order).CurrentValues.SetValues(update);
+
+        if (update.OrderDetails != null)
+        {
+            order.OrderDetails ??= [];
+            order.OrderDetails.Clear();
+            foreach (var detail in update.OrderDetails)
+            {
+                detail.Product = detail.ProductId.HasValue ? await ctx.Product.FindAsync(detail.ProductId.Value) : null;
+                order.OrderDetails.Add(detail);
+            }
+        }
+
+        await ctx.SaveChangesAsync();
+
+        return Ok(order);
+    }
+
+    [HttpPatch("{key}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<Order>> PatchAsync(long key, Delta<Order> delta)
+    {
+        var order = await ctx.Order.Include(x => x.Customer).Include(x => x.OrderDetails).ThenInclude(x => x.Product).FirstOrDefaultAsync(x => x.Id == key);
+
+        if (order == null)
+        {
+            return NotFound();
+        }
+
+        delta.Patch(order);
+
+        await ctx.SaveChangesAsync();
+
+        return Ok(order);
+    }
+
+    [HttpDelete("{key}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> DeleteAsync(long key)
+    {
+        var order = await ctx.Order.Include(x => x.OrderDetails).FirstOrDefaultAsync(x => x.Id == key);
+
+        if (order != null)
+        {
+            ctx.Order.Remove(order);
+            await ctx.SaveChangesAsync();
+        }
+
+        return NoContent();
+    }
+}

--- a/NapoleonCRM/Data/ApplicationDbContext.cs
+++ b/NapoleonCRM/Data/ApplicationDbContext.cs
@@ -49,6 +49,8 @@ public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options
     public DbSet<Product> Product => Set<Product>();
     public DbSet<Service> Service => Set<Service>();
     public DbSet<Sale> Sale => Set<Sale>();
+    public DbSet<Order> Order => Set<Order>();
+    public DbSet<OrderDetail> OrderDetail => Set<OrderDetail>();
     public DbSet<Vendor> Vendor => Set<Vendor>();
     public DbSet<SupportCase> SupportCase => Set<SupportCase>();
     public DbSet<TodoTask> TodoTask => Set<TodoTask>();
@@ -100,6 +102,30 @@ public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options
         modelBuilder.Entity<Sale>()
             .Property(e => e.TotalAmount)
             .HasPrecision(19, 4);
+        modelBuilder.Entity<Order>()
+            .Property(e => e.TotalAmount)
+            .HasConversion<double>();
+        modelBuilder.Entity<Order>()
+            .Property(e => e.TotalAmount)
+            .HasPrecision(19, 4);
+        modelBuilder.Entity<Order>()
+            .HasOne(x => x.Customer);
+        modelBuilder.Entity<Order>()
+            .HasMany(x => x.OrderDetails);
+        modelBuilder.Entity<OrderDetail>()
+            .Property(e => e.UnitPrice)
+            .HasConversion<double>();
+        modelBuilder.Entity<OrderDetail>()
+            .Property(e => e.UnitPrice)
+            .HasPrecision(19, 4);
+        modelBuilder.Entity<OrderDetail>()
+            .Property(e => e.TotalPrice)
+            .HasConversion<double>();
+        modelBuilder.Entity<OrderDetail>()
+            .Property(e => e.TotalPrice)
+            .HasPrecision(19, 4);
+        modelBuilder.Entity<OrderDetail>()
+            .HasOne(x => x.Product);
         modelBuilder.Entity<Vendor>()
             .HasOne(x => x.Address);
         modelBuilder.Entity<Vendor>()

--- a/NapoleonCRM/Program.cs
+++ b/NapoleonCRM/Program.cs
@@ -54,6 +54,8 @@ modelBuilder.EntitySet<ApplicationUserDto>("User");
 modelBuilder.EntitySet<Country>("Country");
 modelBuilder.EntitySet<Currency>("Currency");
 modelBuilder.EntitySet<CategoryFirst>("CategoryFirst");
+modelBuilder.EntitySet<Order>("Order");
+modelBuilder.EntitySet<OrderDetail>("OrderDetail");
 
 builder.Services.AddControllers()
     .AddOData(options => options.EnableQueryFeatures().AddRouteComponents("odata", modelBuilder.GetEdmModel()))


### PR DESCRIPTION
## Summary
- add Order and OrderDetail models
- implement OrderController with CRUD and related includes
- register Order endpoints and model in program and DbContext

## Testing
- `dotnet build NapoleonCRM.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68affc6709388329bf8c8909ea7d9d53